### PR TITLE
【API】カテゴリーの一覧表示〜選択・解除

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ docker compose run --rm api rails db:create
 docker-compose run --rm api rails db:migrate
 ```
 
-## Seed作成
+## ダミーデータ作成
 ```
-docker compose run --rm api rails db:seed
+docker compose run --rm api rails dummy:all_data
 ```
 
 ### 注意点

--- a/app/controllers/api/users/categories_controller.rb
+++ b/app/controllers/api/users/categories_controller.rb
@@ -1,6 +1,0 @@
-class Api::Users::CategoriesController < ApplicationController
-  def index
-    categories = Category.all.order(created_at: "ASC")
-    render json: { status: "SUCCESS", message: "カテゴリーの一覧表示", categories: categories }, status: 200
-  end
-end

--- a/app/controllers/api/users/categories_controller.rb
+++ b/app/controllers/api/users/categories_controller.rb
@@ -1,0 +1,6 @@
+class Api::Users::CategoriesController < ApplicationController
+  def index
+    categories = Category.all.order(created_at: "ASC")
+    render json: { status: "SUCCESS", message: "カテゴリーの一覧表示", categories: categories }, status: 200
+  end
+end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::CategoriesController < ApplicationController
-  include SessionsHelper
-  before_action :logged_in, only: [:index, :selected_category, :reset_category]
+  before_action :login_required, only: [:index, :selected_category, :reset_category]
   before_action :set_category, only: [:selected_category]
 
   def index
@@ -47,11 +46,5 @@ class Api::V1::CategoriesController < ApplicationController
 
   def user_category_params
     params.permit(:user_id, :category_id)
-  end
-
-  def logged_in
-    unless logged_in?
-      render json: { error: "ログインしてください" }, status: 401
-    end
   end
 end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::CategoriesController < ApplicationController
 
     if user_category.present?
       user_category.discard
-      render json: { status: 'SUCCESS', message: "カテゴリーの選択を解除しました" }, status: 204
+      render json: { status: 'SUCCESS', message: "カテゴリーの選択を解除しました", data: user_category }, status: 200
     else
       render json: { status: 'ERROR', message: "カテゴリーの選択解除に失敗しました" }, status: 422
     end
@@ -41,7 +41,7 @@ class Api::V1::CategoriesController < ApplicationController
   private
 
   def set_category
-    @category = Category.find(params[:category_id])
+    category = Category.find(params[:category_id])
   end
 
   def user_category_params

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,34 @@
+class Api::V1::CategoriesController < ApplicationController
+  include SessionsHelper
+  before_action :logged_in, only: [:index, :selected_category]
+
+  def index
+    categories = Category.all.order(created_at: "ASC")
+    render json: { status: "SUCCESS", message: "カテゴリーの一覧表示", categories: categories }, status: 200
+  end
+
+  def selected_category
+    category = Category.find(params[:category_id])
+
+    user_category = UserCategory.new(user_category_params)
+
+    if current_user && category.present?
+      user_category.save
+      render json: { status: 'SUCCESS', message: "選択したカテゴリーの保存に成功しました", data: user_category }, status: 200
+    else
+      render json: { status: 'ERROR', message: "選択したカテゴリーの保存に失敗しました" }, status: 422
+    end
+  end
+
+  private
+
+  def user_category_params
+    params.permit(:user_id, :category_id)
+  end
+
+  def logged_in
+    unless logged_in?
+      render json: { error: "ログインしてください" }, status: 401
+    end
+  end
+end

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -8,11 +8,10 @@ class Api::V1::CategoriesController < ApplicationController
   end
 
   def selected_category
-    category = Category.find(params[:category_id])
-
+    find_category
     user_category = UserCategory.new(user_category_params)
 
-    if current_user && category.present?
+    if current_user && @category.present?
       user_category.save
       render json: { status: 'SUCCESS', message: "選択したカテゴリーの保存に成功しました", data: user_category }, status: 200
     else
@@ -20,7 +19,21 @@ class Api::V1::CategoriesController < ApplicationController
     end
   end
 
+  # def reset_category
+  #   user_category = UserCategory.find(params[:category_id])
+
+  #   if current_user && user_category&.discard
+  #     render json: { status: 'SUCCESS', message: "カテゴリーの選択を解除しました", data: user_category }, status: 204
+  #   else
+  #     render json: { status: 'ERROR', message: "カテゴリーの選択解除に失敗しました" }, status: 422
+  #   end
+  # end
+
   private
+
+  def find_category
+    @category = Category.find(params[:category_id])
+  end
 
   def user_category_params
     params.permit(:user_id, :category_id)

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -13,17 +13,15 @@ class Api::V1::CategoriesController < ApplicationController
 
     reselect_category = UserCategory.with_discarded.find_by(user_category_params)
 
-    # カテゴリーを再選択する
-    if reselect_category.discarded?
+    # カテゴリーの再選択
+    if reselect_category.present?
       reselect_category.undiscard!
       render json: { status: 'SUCCESS', message: "再度選択したカテゴリーを保存しました", data: reselect_category }, status: 200
+    # 初回のカテゴリー選択
+    elsif user_category.save!
+      render json: { status: 'SUCCESS', message: "選択したカテゴリーを保存しました", data: user_category }, status: 200
     else
-      # 最初のカテゴリー選択
-      if user_category.save
-        render json: { status: 'SUCCESS', message: "選択したカテゴリーを保存しました", data: user_category }, status: 200
-      else
-        render json: { status: 'ERROR', message: "選択したカテゴリーの保存に失敗しました" }, status: 422
-      end
+      render json: { status: 'ERROR', message: "選択したカテゴリーの保存に失敗しました" }, status: 422
     end
   end
 

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -13,21 +13,17 @@ class Api::V1::CategoriesController < ApplicationController
     user_category = UserCategory.new(user_category_params)
     reselected_category = UserCategory.with_discarded.find_by(user_category_params)
 
-    if reselected_category.present?
-      reselected_category.undiscard!
-      category = reselected_category
-    else
-      category = user_category
-    end
+    category = if reselected_category.present?
+                reselected_category.undiscard!
+                reselected_category
+              else
+                user_category
+              end
 
-    if category.save!
-      render json: { status: 'SUCCESS', message: "選択したカテゴリーを保存しました", data: category }, status: 200
-    else
-      render json: { status: 'ERROR', message: "選択したカテゴリーの保存に失敗しました" }, status: 422
-    end
+    return render_error(422, "選択したカテゴリーの保存に失敗しました") unless category.save!
+
+    render json: { status: 'SUCCESS', message: "選択したカテゴリーを保存しました", data: category }, status: 200
   rescue StandardError => e
-    puts e.class
-    puts e.message
     render json: { status: 'ERROR', message: "例外エラーが発生しました", error: [e.class, e.message] }, status: 500
   end
 

--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -13,21 +13,23 @@ class Api::V1::CategoriesController < ApplicationController
 
     if current_user && @category.present?
       user_category.save
-      render json: { status: 'SUCCESS', message: "選択したカテゴリーの保存に成功しました", data: user_category }, status: 200
+      render json: { status: 'SUCCESS', message: "選択したカテゴリーの保存に成功しました" }, status: 200
     else
       render json: { status: 'ERROR', message: "選択したカテゴリーの保存に失敗しました" }, status: 422
     end
   end
 
-  # def reset_category
-  #   user_category = UserCategory.find(params[:category_id])
+  def reset_category
+    user_category = UserCategory.find_by(user_id: params[:user_id], category_id: params[:category_id])
+    puts "uc: #{user_category}"
 
-  #   if current_user && user_category&.discard
-  #     render json: { status: 'SUCCESS', message: "カテゴリーの選択を解除しました", data: user_category }, status: 204
-  #   else
-  #     render json: { status: 'ERROR', message: "カテゴリーの選択解除に失敗しました" }, status: 422
-  #   end
-  # end
+    if current_user && user_category.present?
+      user_category&.discard
+      render json: { status: 'SUCCESS', message: "カテゴリーの選択を解除しました", data: user_category }, status: 204
+    else
+      render json: { status: 'ERROR', message: "カテゴリーの選択解除に失敗しました" }, status: 422
+    end
+  end
 
   private
 

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Api::Users::SessionsController < ApplicationController
+class Api::V1::SessionsController < ApplicationController
   skip_before_action :login_required, only: [ :new, :create ]
   require "omniauth-auth0"
   require "uri"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
 
   def login_required
     unless logged_in?
+      render json: { message: "ログインしてください" }, status: 401
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 30 }
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,5 @@
 class Category < ApplicationRecord
+  has_many :user_categories
+  has_many :users, through: :user_categories
   validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,7 @@
 class Category < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   has_many :user_categories
   has_many :users, through: :user_categories
   validates :name, presence: true, length: { maximum: 30 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :user_categories
+  has_many :categories, through: :user_categories
+
   has_secure_password
 
   validates :name, presence: true, length: { maximum: 100 }

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -1,0 +1,4 @@
+class UserCategory < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+end

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -1,4 +1,7 @@
 class UserCategory < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   belongs_to :user
   belongs_to :category
 

--- a/app/models/user_category.rb
+++ b/app/models/user_category.rb
@@ -1,4 +1,6 @@
 class UserCategory < ApplicationRecord
   belongs_to :user
   belongs_to :category
+
+  validates :user_id, uniqueness: { scope: :category_id }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,8 @@ ja:
   activerecord:
     models:
         user: ユーザー
+        category: カテゴリー
+        user_category: 選択カテゴリー
     attributes:
       user:
         name: "名前"
@@ -9,6 +11,11 @@ ja:
         password: "パスワード"
         auth0_id: "Auth0_ID"
         is_admin: "管理者権限"
+      category:
+        name: "カテゴリー名"
+      user_category:
+        user_id: "ユーザーID"
+        category_id: "カテゴリーID"
     errors:
       format: "%{attribute}%{message}"
       models:
@@ -25,6 +32,17 @@ ja:
             password:
               blank: "を入力してください。"
             auth0_id:
+              taken: "はすでに存在します"
+        category:
+          attributes:
+            name:
+              blank: "を入力してください。"
+              too_long: "は30文字以内で入力してください"
+        user_category:
+          attributes:
+            user_id:
+              taken: "はすでに存在します"
+            category_id:
               taken: "はすでに存在します"
       messages:
         required: "%{attribute}は必須項目です。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace "api" do
-    namespace "users" do
+    namespace "v1" do
       get "/login", to: "sessions#new"
       post "/login", to: "sessions#create"
       delete "/logout", to: "sessions#destroy", as: :logout
@@ -9,7 +9,11 @@ Rails.application.routes.draw do
       get "/auth/failure" => "auth0#failure"
       get "/auth/logout" => "auth0#logout"
 
-      resources :categories
+      resources :categories, only: [:index]
+
+      resources :users, only: [:create, :show, :update, :destroy] do
+        post 'categories/:id', to: 'categories#selected_category'
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
       resources :users, only: [:create, :show, :update, :destroy] do
         post 'categories/:id', to: 'categories#selected_category'
-        delete 'categories/:id', to: 'categories#reset_category'
+        patch 'categories/:id', to: 'categories#reset_category'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
       resources :users, only: [:create, :show, :update, :destroy] do
         post 'categories/:id', to: 'categories#selected_category'
-        # delete 'categories/:id', to: 'categories#reset_category'
+        delete 'categories/:id', to: 'categories#reset_category'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
       resources :users, only: [:create, :show, :update, :destroy] do
         post 'categories/:id', to: 'categories#selected_category'
+        # delete 'categories/:id', to: 'categories#reset_category'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
       get "/auth/auth0/callback" => "auth0#create"
       get "/auth/failure" => "auth0#failure"
       get "/auth/logout" => "auth0#logout"
+
+      resources :categories
     end
   end
 end

--- a/db/migrate/20241209211349_create_categories.rb
+++ b/db/migrate/20241209211349_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241209211349_create_categories.rb
+++ b/db/migrate/20241209211349_create_categories.rb
@@ -2,6 +2,7 @@ class CreateCategories < ActiveRecord::Migration[7.2]
   def change
     create_table :categories do |t|
       t.string :name
+      t.datetime :discarded_at
 
       t.timestamps
     end

--- a/db/migrate/20241209214348_create_user_categories.rb
+++ b/db/migrate/20241209214348_create_user_categories.rb
@@ -3,7 +3,7 @@ class CreateUserCategories < ActiveRecord::Migration[7.2]
     create_table :user_categories do |t|
       t.references :user, null: false, foreign_key: true
       t.references :category, null: false, foreign_key: true
-      t.string :is_selected
+      t.datetime :discarded_at
 
       t.timestamps
     end

--- a/db/migrate/20241209214348_create_user_categories.rb
+++ b/db/migrate/20241209214348_create_user_categories.rb
@@ -1,0 +1,11 @@
+class CreateUserCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_categories do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+      t.string :is_selected
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241209214348_create_user_categories.rb
+++ b/db/migrate/20241209214348_create_user_categories.rb
@@ -7,5 +7,6 @@ class CreateUserCategories < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
+    add_index :user_categories, [:user_id, :category_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_29_232933) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_09_211349) do
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "auth0_id"
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema[7.2].define(version: 2024_12_09_214348) do
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
+    t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_214348) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_user_categories_on_category_id"
+    t.index ["user_id", "category_id"], name: "index_user_categories_on_user_id_and_category_id", unique: true
     t.index ["user_id"], name: "index_user_categories_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_211349) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_09_214348) do
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "user_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_user_categories_on_category_id"
+    t.index ["user_id"], name: "index_user_categories_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -28,4 +38,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_211349) do
     t.datetime "updated_at", null: false
     t.index ["auth0_id", "email"], name: "index_users_on_auth0_id_and_email", unique: true
   end
+
+  add_foreign_key "user_categories", "categories"
+  add_foreign_key "user_categories", "users"
 end

--- a/lib/tasks/dummy_all_data.rake
+++ b/lib/tasks/dummy_all_data.rake
@@ -10,6 +10,9 @@ namespace :dummy do
       puts "--- dummy:userinfo ----"
       Rake::Task["dummy:user_info"].invoke
 
+      puts "--- dummy:categoryinfo ----"
+      Rake::Task["dummy:category_info"].invoke
+
       puts "--- end ---"
     end
   end

--- a/lib/tasks/dummy_category_info.rake
+++ b/lib/tasks/dummy_category_info.rake
@@ -1,0 +1,21 @@
+namespace :dummy do
+  desc "Create new categories"
+  task category_info: :environment do
+    begin
+      categories = [
+        { name: "コミュニケーション" },
+        { name: "マインド" },
+        { name: "ビジネススキル" },
+        { name: "お金" },
+        { name: "心理学" }
+      ]
+
+      categories.each do |category|
+        Category.create!(category)
+      end
+    rescue StandardError => e
+      puts "--- カテゴリー作成中のエラー ---"
+      puts e.class, e.message
+    end
+  end
+end

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    name { 'Communication' }
+    discarded_at { nil }
+  end
+end

--- a/spec/factories/user_category.rb
+++ b/spec/factories/user_category.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_category do
+    association :user
+    association :category
+  end
+end

--- a/spec/models/user_category_spec.rb
+++ b/spec/models/user_category_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe UserCategory, type: :model do
+  context 'Soft Delete' do
+    it 'Soft deleted of UserCategory is nil' do
+      user_category = create(:user_category)
+
+      expect(user_category.discarded_at).to be_nil
+    end
+
+    it 'Soft deleted of UserCategory is exist' do
+      user_category = create(:user_category)
+      user_category.discard
+
+      expect(user_category.discarded_at).to be_present
+    end
+
+    it 'Soft deleted of UserCategory is restored' do
+      user_category = create(:user_category)
+      user_category.discard
+      user_category.undiscard
+
+      expect(user_category.discarded_at).to be_nil
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -5,26 +5,26 @@ RSpec.describe 'Sessions', type: :system do
 
   context 'Login' do
     it 'Login is successful if the user information is correct' do
-      post api_users_login_path, params: { email: user.email, password: user.password }
+      post api_v1_login_path, params: { email: user.email, password: user.password }
 
       expect(response).to have_http_status(200)
     end
 
     it 'Login fails when user information is invalid' do
-      post api_users_login_path, params: { user: { email: "test@example.com", password: "password" } }
+      post api_v1_login_path, params: { user: { email: "test@example.com", password: "password" } }
       expect(response).to have_http_status(401)
     end
   end
 
   context 'Logout' do
     it 'Success Logout' do
-      post api_users_login_path, params: { email: user.email, password: user.password }
-      delete api_users_logout_path
+      post api_v1_login_path, params: { email: user.email, password: user.password }
+      delete api_v1_logout_path
       expect(response).to have_http_status(200)
     end
 
     it 'Failed Logout (when already logged out)' do
-      delete api_users_logout_path
+      delete api_v1_logout_path
 
       expect(response).to have_http_status(401)
     end

--- a/test/controllers/api/users/categories_controller_test.rb
+++ b/test/controllers/api/users/categories_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::Users::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/user_categories.yml
+++ b/test/fixtures/user_categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  category: one
+  is_selected: MyString
+
+two:
+  user: two
+  category: two
+  is_selected: MyString

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_category_test.rb
+++ b/test/models/user_category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケット
- [（バックエンド）ジャンル表示・選択状態の保存・選択リセット](https://trello.com/c/Po2oDPyH)

# 実装内容
- categoriesテーブル、中間テーブル（user_categories）の追加
- カテゴリーのダミーデータ追加
- カテゴリーの一覧表示
- 選択されたカテゴリーの保存、選択解除（=論理削除）
- カテゴリーの再選択（保存）

## レスポンスJSON
- カテゴリーの一覧表示
<img width="775" alt="スクリーンショット 2024-12-10 6 34 19" src="https://github.com/user-attachments/assets/dc4578a2-d003-4dcc-95a6-ce1d9ca6f9c3" />

- カテゴリーの選択（保存）
<img width="722" alt="スクリーンショット 2024-12-13 6 21 34" src="https://github.com/user-attachments/assets/67ad6f8a-ce2f-43d8-be47-7d9910fac70e" />

- カテゴリーの選択解除（論理削除）
<img width="672" alt="スクリーンショット 2024-12-13 6 18 21" src="https://github.com/user-attachments/assets/ee404e89-0c9b-4b4c-8617-97590c46bc35" />

- カテゴリーの再選択（保存）
<img width="723" alt="スクリーンショット 2024-12-13 6 17 57" src="https://github.com/user-attachments/assets/3aac3d5b-3de4-4f17-a872-af47903ab107" />

## 備考・注意点
- カテゴリーの一覧表示、保存・論理削除はログイン時に実行される仕様です。
- user_idとcategory_idは一意の組み合わせで保存されます。