### PR TITLE
【ダミーデータ】クイズ問題と正解データ

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,5 +4,7 @@ class Category < ApplicationRecord
 
   has_many :user_categories
   has_many :users, through: :user_categories
+  has_many :quiz_questions
+
   validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -1,0 +1,5 @@
+module Quiz
+  def self.table_name_prefix
+    "quiz_"
+  end
+end

--- a/app/models/quiz/answer.rb
+++ b/app/models/quiz/answer.rb
@@ -1,2 +1,3 @@
 class Quiz::Answer < ApplicationRecord
+  belongs_to :quiz_question, class_name: 'Quiz::Question'
 end

--- a/app/models/quiz/answer.rb
+++ b/app/models/quiz/answer.rb
@@ -1,0 +1,2 @@
+class Quiz::Answer < ApplicationRecord
+end

--- a/app/models/quiz/question.rb
+++ b/app/models/quiz/question.rb
@@ -1,0 +1,2 @@
+class Quiz::Question < ApplicationRecord
+end

--- a/app/models/quiz/question.rb
+++ b/app/models/quiz/question.rb
@@ -1,2 +1,5 @@
 class Quiz::Question < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+  has_many :answers
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :user_categories
   has_many :categories, through: :user_categories
+  has_many :quiz_questions
 
   has_secure_password
 

--- a/db/migrate/20241216100256_create_quiz_questions.rb
+++ b/db/migrate/20241216100256_create_quiz_questions.rb
@@ -1,0 +1,13 @@
+class CreateQuizQuestions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :quiz_questions do |t|
+      t.string :title
+      t.string :question
+      t.datetime :discarded_at
+      t.references :user, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241216102134_create_quiz_answers.rb
+++ b/db/migrate/20241216102134_create_quiz_answers.rb
@@ -4,7 +4,7 @@ class CreateQuizAnswers < ActiveRecord::Migration[7.2]
       t.string :quiz_option
       t.boolean :is_answer
       t.datetime :discarded_at
-      t.references :quiz_questions, null: false, foreign_key: true
+      t.references :quiz_question, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20241216102134_create_quiz_answers.rb
+++ b/db/migrate/20241216102134_create_quiz_answers.rb
@@ -1,0 +1,12 @@
+class CreateQuizAnswers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :quiz_answers do |t|
+      t.string :quiz_option
+      t.boolean :is_answer
+      t.datetime :discarded_at
+      t.references :quiz_questions, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,10 +22,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_102134) do
     t.string "quiz_option"
     t.boolean "is_answer"
     t.datetime "discarded_at"
-    t.bigint "quiz_questions_id", null: false
+    t.bigint "quiz_question_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["quiz_questions_id"], name: "index_quiz_answers_on_quiz_questions_id"
+    t.index ["quiz_question_id"], name: "index_quiz_answers_on_quiz_question_id"
   end
 
   create_table "quiz_questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_102134) do
     t.index ["auth0_id", "email"], name: "index_users_on_auth0_id_and_email", unique: true
   end
 
-  add_foreign_key "quiz_answers", "quiz_questions", column: "quiz_questions_id"
+  add_foreign_key "quiz_answers", "quiz_questions"
   add_foreign_key "quiz_questions", "categories"
   add_foreign_key "quiz_questions", "users"
   add_foreign_key "user_categories", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_09_214348) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_102134) do
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "quiz_answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "quiz_option"
+    t.boolean "is_answer"
+    t.datetime "discarded_at"
+    t.bigint "quiz_questions_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["quiz_questions_id"], name: "index_quiz_answers_on_quiz_questions_id"
+  end
+
+  create_table "quiz_questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title"
+    t.string "question"
+    t.datetime "discarded_at"
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_quiz_questions_on_category_id"
+    t.index ["user_id"], name: "index_quiz_questions_on_user_id"
   end
 
   create_table "user_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -41,6 +63,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_09_214348) do
     t.index ["auth0_id", "email"], name: "index_users_on_auth0_id_and_email", unique: true
   end
 
+  add_foreign_key "quiz_answers", "quiz_questions", column: "quiz_questions_id"
+  add_foreign_key "quiz_questions", "categories"
+  add_foreign_key "quiz_questions", "users"
   add_foreign_key "user_categories", "categories"
   add_foreign_key "user_categories", "users"
 end

--- a/lib/tasks/dummy_all_data.rake
+++ b/lib/tasks/dummy_all_data.rake
@@ -13,6 +13,12 @@ namespace :dummy do
       puts "--- dummy:categoryinfo ----"
       Rake::Task["dummy:category_info"].invoke
 
+      puts "--- dummy:quiz_question_info ----"
+      Rake::Task["dummy:quiz_question_info"].invoke
+
+      puts "--- dummy:quiz_answer_info ----"
+      Rake::Task["dummy:quiz_answer_info"].invoke
+
       puts "--- end ---"
     end
   end

--- a/lib/tasks/dummy_quiz_answer_info.rake
+++ b/lib/tasks/dummy_quiz_answer_info.rake
@@ -1,0 +1,57 @@
+namespace :dummy do
+  desc "Create new quizzes"
+  task quiz_answer_info: :environment do
+    begin
+      quiz_answers = [
+        { quiz_option: "純利益", is_answer: false, quiz_question_id: 1 },
+        { quiz_option: "消費税", is_answer: false, quiz_question_id: 1 },
+        { quiz_option: "所得控除", is_answer: true, quiz_question_id: 1 }, #正解
+        { quiz_option: "税額控除", is_answer: false, quiz_question_id: 1 },
+        { quiz_option: "A.才能 B.努力", is_answer: false, quiz_question_id: 2 },
+        { quiz_option: "A.努力 B.才能", is_answer: true, quiz_question_id: 2 }, #正解
+        { quiz_option: "A.性格 B.知識", is_answer: false, quiz_question_id: 2 },
+        { quiz_option: "A.知識 B.性格", is_answer: false, quiz_question_id: 2 },
+        { quiz_option: "服装", is_answer: false, quiz_question_id: 3 },
+        { quiz_option: "話の速度", is_answer: true, quiz_question_id: 3 }, #正解
+        { quiz_option: "目", is_answer: false, quiz_question_id: 3 },
+        { quiz_option: "性格", is_answer: false, quiz_question_id: 3 },
+        { quiz_option: "視覚情報", is_answer: true, quiz_question_id: 4 }, #正解
+        { quiz_option: "言語情報", is_answer: false, quiz_question_id: 4 },
+        { quiz_option: "聴覚情報", is_answer: false, quiz_question_id: 4 },
+        { quiz_option: "直感", is_answer: false, quiz_question_id: 4 },
+        { quiz_option: "医療費が高額になった場合の患者の負担を軽減する", is_answer: true, quiz_question_id: 5 }, #正解
+        { quiz_option: "医療機関の収入を増やす", is_answer: false, quiz_question_id: 5 },
+        { quiz_option: "医療保険料を安くする", is_answer: false, quiz_question_id: 5 },
+        { quiz_option: "医療サービスの質を向上させる", is_answer: false, quiz_question_id: 5 },
+        { quiz_option: "最新のニュースや時事ネタ", is_answer: false, quiz_question_id: 6 },
+        { quiz_option: "趣味", is_answer: false, quiz_question_id: 6 },
+        { quiz_option: "宗教や政治", is_answer: true, quiz_question_id: 6 }, #正解
+        { quiz_option: "相手の持ち物や服装", is_answer: false, quiz_question_id: 6 },
+        { quiz_option: "相手の言ったことをオウム返しする", is_answer: false, quiz_question_id: 7 },
+        { quiz_option: "あいづちを打つ", is_answer: false, quiz_question_id: 7 },
+        { quiz_option: "相手と同じ仕草をする", is_answer: false, quiz_question_id: 7 },
+        { quiz_option: "伝えなければいけないことは相手の話を遮ってでも伝える", is_answer: true, quiz_question_id: 7 }, #正解
+        { quiz_option: "具体的な表現で伝える", is_answer: false, quiz_question_id: 8 },
+        { quiz_option: "個人の都合で引き受けられないと伝える", is_answer: true, quiz_question_id: 8 }, #正解
+        { quiz_option: "理由よりも感謝や謝罪の言葉を伝える", is_answer: false, quiz_question_id: 8 },
+        { quiz_option: "代案を提示する", is_answer: false, quiz_question_id: 8 },
+        { quiz_option: "仕事が完了した時", is_answer: false, quiz_question_id: 9 },
+        { quiz_option: "商談や会議の直前", is_answer: true, quiz_question_id: 9 }, #正解
+        { quiz_option: "仕事でミスをした時", is_answer: false, quiz_question_id: 9 },
+        { quiz_option: "仕事が途中の時", is_answer: false, quiz_question_id: 9 },
+        { quiz_option: "推し活", is_answer: false, quiz_question_id: 10 },
+        { quiz_option: "家賃・光熱費", is_answer: false, quiz_question_id: 10 },
+        { quiz_option: "健康・美容", is_answer: false, quiz_question_id: 10 },
+        { quiz_option: "SNSの映えを意識した買い物", is_answer: true, quiz_question_id: 10 } #正解
+      ]
+
+      quiz_answers.each do |answer|
+        Quiz::Answer.create!(answer)
+      end
+
+    rescue StandardError => e
+      puts "--- クイズの正解データ作成中のエラー ---"
+      puts e.class, e.message
+    end
+  end
+end

--- a/lib/tasks/dummy_quiz_question_info.rake
+++ b/lib/tasks/dummy_quiz_question_info.rake
@@ -1,0 +1,27 @@
+namespace :dummy do
+  desc "Create new quiz_question"
+  task quiz_question_info: :environment do
+    begin
+      quiz_questions = [
+        { title: "所得税", question: "所得税は、以下のような計算式で計算される。売上 - 必要経費 -  ⚪︎ = 課税所得 課税所得 × 税率 - 控除額 = 所得税 ⚪︎に入る言葉は？", user_id: 2, category_id: 4 },
+        { title: "2つのマインドセット", question: "心理学者のキャロル・S・ドゥエックは、「しなやかマインドセット」と「硬直マインドセット」という考え方を紹介しています。A.「しなやかマインドセット」で変えられるものと、B.「硬直マインドセット」で変えられないものと考えられている組み合わせで、最も適切なものはどれか。", user_id: 2, category_id: 2 },
+        { title: "ペーシング", question: "ペーシングとは、相手とのペースを合わせるコミュニケーションスキルです。相手の話し方や行動を観察し、⚪︎や声の高さ、相づちや頷きのタイミング、話し方、声のトーンなどを相手に合わせます。○に入る言葉は？", user_id: 2, category_id: 1 },
+        { title: "メラビアンの法則", question: "コミュニケーションにおいて、人に一番影響を与えるのは？", user_id: 2, category_id: 1 },
+        { title: "高額療養費制度", question: "高額療養費制度の主な目的は次のうちどれでしょうか？", user_id: 2, category_id: 4 },
+        { title: "雑談", question: "雑談の時の話題として不適切なのはどれか？", user_id: 2, category_id: 1 },
+        { title: "傾聴", question: "相手の話を傾聴するときに不適切な行動はどれか？", user_id: 2, category_id: 1 },
+        { title: "タスク管理", question: "あなたは複数の仕事を抱えているとします。上司から追加で仕事を頼まれて断る時の不適切な行動は？", user_id: 2, category_id: 3 },
+        { title: "報連相", question: "上司への報告・相談を行うタイミングとして不適切なのは？", user_id: 2, category_id: 3 },
+        { title: "浪費", question: "次の4つのうちから浪費になりうるものはどれか", user_id: 2, category_id: 4 }
+      ]
+
+      quiz_questions.each do |question|
+        Quiz::Question.create!(question)
+      end
+
+    rescue StandardError => e
+      puts "--- クイズ問題データ作成中のエラー ---"
+      puts e.class, e.message
+    end
+  end
+end

--- a/test/fixtures/quiz/answers.yml
+++ b/test/fixtures/quiz/answers.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  quiz_option: MyString
+  is_answer: false
+
+two:
+  quiz_option: MyString
+  is_answer: false

--- a/test/fixtures/quiz/questions.yml
+++ b/test/fixtures/quiz/questions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  question: MyString
+
+two:
+  title: MyString
+  question: MyString

--- a/test/models/quiz/answer_test.rb
+++ b/test/models/quiz/answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Quiz::AnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/quiz/question_test.rb
+++ b/test/models/quiz/question_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Quiz::QuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケット
- [（バックエンド）クイズ問題と選択肢の表示](https://trello.com/c/uO5fPAIV)

# 実装内容
- テーブル・マイグレーション追加（quiz_questions, quiz_answers）
- クイズ問題、クイズの正解/不正解のダミーデータ追加

## レスポンスJSON
- クイズ問題
![スクリーンショット 2024-12-18 21 50 12（2）](https://github.com/user-attachments/assets/51641a3f-8e34-4eae-b6d1-20d6e53fdc7a)

- クイズ正解/不正解
![スクリーンショット 2024-12-18 21 51 17（2）](https://github.com/user-attachments/assets/a78d0af9-8c03-4d10-b98a-8c8a3a5948cc)

## 備考・注意点
- 次のPRでクイズ問題および選択肢（正解/不正解）の表示を実装。