### PR TITLE
【API】クイズの問題・選択肢表示

### DIFF
--- a/app/controllers/api/v1/quiz/questions_controller.rb
+++ b/app/controllers/api/v1/quiz/questions_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::Quiz::QuestionsController < ApplicationController
+  skip_before_action :login_required, only: [:show]
+  before_action :set_selected_category, only: [:show]
+
+  def show
+    if @user_category
+      @quiz_question = Quiz::Question.where(category_id: @user_category.category_id).order("RAND()").first
+      @quiz_options = Quiz::Answer.where(quiz_question_id: @quiz_question)
+      render json: { status: "SUCCESS", message: "クイズデータを取得しました", quiz_question: @quiz_question, quiz_options: @quiz_options }, status: 200
+    else
+      render json: { status: "ERROR", message: "クイズデータを取得できませんでした" }, status: 422
+    end
+  rescue StandardError => e
+    render json: { status: 'ERROR', message: "例外エラーが発生しました", error: [e.class, e.message] }, status: 500
+  end
+
+  private
+
+  def set_selected_category
+    @user_category = UserCategory.find_by(category_id: params[:category_id])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  namespace "api" do
-    namespace "v1" do
+  namespace :api do
+    namespace :v1 do
       get "/login", to: "sessions#new"
       post "/login", to: "sessions#create"
       delete "/logout", to: "sessions#destroy", as: :logout
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
       resources :users, only: [:create, :show, :update, :destroy] do
         post 'categories/:id', to: 'categories#selected_category'
         patch 'categories/:id', to: 'categories#reset_category'
+      end
+
+      namespace :quiz do
+        resources :questions, only: [:index, :show]
       end
     end
   end

--- a/lib/tasks/dummy_quiz_answer_info.rake
+++ b/lib/tasks/dummy_quiz_answer_info.rake
@@ -42,7 +42,11 @@ namespace :dummy do
         { quiz_option: "推し活", is_answer: false, quiz_question_id: 10 },
         { quiz_option: "家賃・光熱費", is_answer: false, quiz_question_id: 10 },
         { quiz_option: "健康・美容", is_answer: false, quiz_question_id: 10 },
-        { quiz_option: "SNSの映えを意識した買い物", is_answer: true, quiz_question_id: 10 } #正解
+        { quiz_option: "SNSの映えを意識した買い物", is_answer: true, quiz_question_id: 10 }, #正解
+        { quiz_option: "責任", is_answer: false, quiz_question_id: 11 },
+        { quiz_option: "プライバシー", is_answer: false, quiz_question_id: 11 },
+        { quiz_option: "課題", is_answer: true, quiz_question_id: 11 }, #正解
+        { quiz_option: "立場", is_answer: false, quiz_question_id: 11 },
       ]
 
       quiz_answers.each do |answer|

--- a/lib/tasks/dummy_quiz_question_info.rake
+++ b/lib/tasks/dummy_quiz_question_info.rake
@@ -12,7 +12,8 @@ namespace :dummy do
         { title: "傾聴", question: "相手の話を傾聴するときに不適切な行動はどれか？", user_id: 2, category_id: 1 },
         { title: "タスク管理", question: "あなたは複数の仕事を抱えているとします。上司から追加で仕事を頼まれて断る時の不適切な行動は？", user_id: 2, category_id: 3 },
         { title: "報連相", question: "上司への報告・相談を行うタイミングとして不適切なのは？", user_id: 2, category_id: 3 },
-        { title: "浪費", question: "次の4つのうちから浪費になりうるものはどれか", user_id: 2, category_id: 4 }
+        { title: "浪費", question: "次の4つのうちから浪費になりうるものはどれか", user_id: 2, category_id: 4 },
+        { title: "アドラー心理学", question: "アドラー心理学において、自分の○○と他者の○○を明確に区別することが大切だと言われる。○○に入る言葉は？", user_id: 2, category_id: 5 }
       ]
 
       quiz_questions.each do |question|

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,6 +1,23 @@
 FactoryBot.define do
   factory :category do
-    name { 'Communication' }
-    discarded_at { nil }
+    trait :communication do
+      { name: 'コミュニケーション', discarded_at: nil }
+    end
+
+    trait :mind do
+      { name: 'マインド', discarded_at: nil }
+    end
+
+    trait :business_skill do
+      { name: 'ビジネススキル', discarded_at: nil }
+    end
+
+    trait :monkey do
+      { name: 'お金', discarded_at: nil }
+    end
+
+    trait :psychology do
+      { name: '心理学', discarded_at: nil }
+    end
   end
 end

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,23 +1,25 @@
 FactoryBot.define do
   factory :category do
+    discarded_at { nil }
+
     trait :communication do
-      { name: 'コミュニケーション', discarded_at: nil }
+      { name: 'コミュニケーション' }
     end
 
     trait :mind do
-      { name: 'マインド', discarded_at: nil }
+      { name: 'マインド' }
     end
 
     trait :business_skill do
-      { name: 'ビジネススキル', discarded_at: nil }
+      { name: 'ビジネススキル' }
     end
 
-    trait :monkey do
-      { name: 'お金', discarded_at: nil }
+    trait :money do
+      { name: 'お金' }
     end
 
     trait :psychology do
-      { name: '心理学', discarded_at: nil }
+      { name: '心理学' }
     end
   end
 end

--- a/spec/factories/quiz/answer.rb
+++ b/spec/factories/quiz/answer.rb
@@ -1,0 +1,83 @@
+FactoryBot.define do
+  factory :quiz_answer do
+    trait :income_tax_option_1 do
+      { quiz_option: '純利益', is_answer: false, quiz_question_id: 1 }
+    end
+
+    trait :income_tax_option_2 do
+      { quiz_option: '消費税', is_answer: false, quiz_question_id: 1 }
+    end
+
+    trait :income_tax_option_3 do
+      { quiz_option: '所得控除', is_answer: true, quiz_question_id: 1 }
+    end
+
+    trait :income_tax_option_4 do
+      { quiz_option: '税額控除', is_answer: false, quiz_question_id: 1 }
+    end
+
+    trait :two_minds_option_1 do
+      { quiz_option: 'A.才能 B.努力', is_answer: false, quiz_question_id: 2 }
+    end
+
+    trait :two_minds_option_2 do
+      { quiz_option: 'A.努力 B.才能', is_answer: true, quiz_question_id: 2 }
+    end
+
+    trait :two_minds_option_3 do
+      { quiz_option: 'A.性格 B.知識', is_answer: false, quiz_question_id: 2 }
+    end
+
+    trait :two_minds_option_4 do
+      { quiz_option: 'A.知識 B.性格', is_answer: false, quiz_question_id: 2 }
+    end
+
+    trait :chat_option_1 do
+      { quiz_option: '最新のニュースや時事ネタ', is_answer: false, quiz_question_id: 3 }
+    end
+
+    trait :chat_option_2 do
+      { quiz_option: '趣味', is_answer: false, quiz_question_id: 3 }
+    end
+
+    trait :chat_option_3 do
+      { quiz_option: '宗教や政治', is_answer: true, quiz_question_id: 3 }
+    end
+
+    trait :chat_option_4 do
+      { quiz_option: '相手の持ち物や服装', is_answer: false, quiz_question_id: 3 }
+    end
+
+    trait :listening_option_1 do
+      { quiz_option: '相手の言ったことをオウム返しする', is_answer: false, quiz_question_id: 4 }
+    end
+
+    trait :listening_option_2 do
+      { quiz_option: 'あいづちを打つ', is_answer: false, quiz_question_id: 4 }
+    end
+
+    trait :listening_option_3 do
+      { quiz_option: '相手と同じ仕草をする', is_answer: false, quiz_question_id: 4 }
+    end
+
+    trait :listening_option_4 do
+      { quiz_option: '伝えなければいけないことは相手の話を遮ってでも伝える', is_answer: true, quiz_question_id: 4 }
+    end
+
+    trait :report_communicate_consult_option_1 do
+      { quiz_option: '仕事が完了した時', is_answer: false, quiz_question_id: 5 }
+    end
+
+    trait :report_communicate_consult_option_2 do
+      { quiz_option: '商談や会議の直前', is_answer: true, quiz_question_id: 5 }
+    end
+
+    trait :report_communicate_consult_option_3 do
+      { quiz_option: '仕事でミスをした時', is_answer: false, quiz_question_id: 5 }
+    end
+
+    trait :report_communicate_consult_option_4 do
+      { quiz_option: '仕事が途中の時', is_answer: false, quiz_question_id: 5 }
+    end
+  end
+end

--- a/spec/factories/quiz/question.rb
+++ b/spec/factories/quiz/question.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :quiz_question do
+    trait :income_tax do
+      { title: '所得税', question: '売上 - 必要経費 -  ⚪︎ = 課税所得。⚪︎に入る言葉は？', user_id: 2, category_id: 4 }
+    end
+
+    trait :two_minds do
+      { title: '2つのマインドセット', question: '「しなやかマインドセット」で変えられるものと、B.「硬直マインドセット」で変えられないものと考えられている組み合わせで、最も適切なものはどれか。', user_id: 2, category_id: 2 }
+    end
+
+    trait :chat do
+      { title: '雑談', question: '雑談の時の話題として不適切なのはどれか？', user_id: 2, category_id: 1 }
+    end
+
+    trait :listening do
+      { title: '雑談', question: '相手の話を傾聴するときに不適切な行動はどれか？', user_id: 2, category_id: 1 }
+    end
+
+    trait :report_communicate_consult do
+      { title: '報連相', question: '上司への報告・相談を行うタイミングとして不適切なのは？', user_id: 2, category_id: 3 }
+    end
+  end
+end

--- a/spec/factories/quiz/question.rb
+++ b/spec/factories/quiz/question.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :listening do
-      { title: '雑談', question: '相手の話を傾聴するときに不適切な行動はどれか？', user_id: 2, category_id: 1 }
+      { title: '傾聴', question: '相手の話を傾聴するときに不適切な行動はどれか？', user_id: 2, category_id: 1 }
     end
 
     trait :report_communicate_consult do

--- a/spec/models/user_category_spec.rb
+++ b/spec/models/user_category_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 RSpec.describe UserCategory, type: :model do
   context 'Soft Delete' do
-    it 'Soft deleted of UserCategory is nil' do
-      user_category = create(:user_category)
+    let(:category) { create(:category, name: 'コミュニケーション') }
+    let(:user_category) { create(:user_category, user: create(:user), category: category) }
 
+    it 'Soft deleted of UserCategory is nil' do
       expect(user_category.discarded_at).to be_nil
     end
 
     it 'Soft deleted of UserCategory is exist' do
-      user_category = create(:user_category)
       user_category.discard
 
       expect(user_category.discarded_at).to be_present
     end
 
     it 'Soft deleted of UserCategory is restored' do
-      user_category = create(:user_category)
+      user_category = create(:user_category, user: create(:user), category: create(:category, name: 'テスト用'))
       user_category.discard
       user_category.undiscard
 

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Categories', type: :system do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+
+  context 'Category list' do
+    it 'Display Success Category list' do
+      post api_v1_login_path, params: { email: user.email, password: user.password }
+      get api_v1_categories_path
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'Display Failure Category list' do
+      get api_v1_categories_path
+
+      expect(response).to have_http_status(401)
+    end
+  end
+end

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -2,23 +2,29 @@ require 'rails_helper'
 
 RSpec.describe 'Quizzes', type: :system do
   let(:user) { create(:user) }
-  let(:category) { create(:category, name: "お金") }
+  let(:category) { create(:category, name: :money) }
   let(:user_category) { create(:user_category, user: user, category: category) }
-  let(:quiz_question) { create(:quiz_question)}
+  let(:quiz_question) { create(:quiz_question) }
+  let(:quiz_answer) { create(:quiz_answer, quiz_option: "純利益") }
+  let(:quiz_answer) { create(:quiz_answer, quiz_option: "消費税") }
+  let(:quiz_answer) { create(:quiz_answer, quiz_option: "所得控除") }
+  let(:quiz_answer) { create(:quiz_answer, quiz_option: "税額控除") }
 
-  context 'Quiz Question' do
-    it 'Display Success Quiz Question' do
+  context 'Quiz Question and Options' do
+    it 'Display Success Quiz Question and Options' do
       post api_v1_login_path, params: { email: user.email, password: user.password }
       get api_v1_quiz_question_path(id: 1), params: { category_id: user_category.category_id }
-      
+
       expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)['quiz_options']).to_not eq nil
     end
 
-    it 'Display Failure Quiz Question' do
+    it 'Display Failure Quiz Question and Options' do
       post api_v1_login_path, params: { email: user.email, password: user.password }
       get api_v1_quiz_question_path(id: 1)
 
       expect(response).to have_http_status(422)
+      expect(JSON.parse(response.body)['quiz_options']).to eq nil
     end
   end
 end

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Quizzes', type: :system do
+  let(:user) { create(:user) }
+  let(:category) { create(:category, name: "お金") }
+  let(:user_category) { create(:user_category, user: user, category: category) }
+  let(:quiz_question) { create(:quiz_question)}
+
+  context 'Quiz Question' do
+    it 'Display Success Quiz Question' do
+      post api_v1_login_path, params: { email: user.email, password: user.password }
+      get api_v1_quiz_question_path(id: 1), params: { category_id: user_category.category_id }
+      
+      expect(response).to have_http_status(200)
+    end
+
+    it 'Display Failure Quiz Question' do
+      post api_v1_login_path, params: { email: user.email, password: user.password }
+      get api_v1_quiz_question_path(id: 1)
+
+      expect(response).to have_http_status(422)
+    end
+  end
+end

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Quizzes', type: :system do
       post api_v1_login_path, params: { email: user.email, password: user.password }
       get api_v1_quiz_question_path(id: 1)
 
-      expect(response).to have_http_status(422)
+      expect(response).to have_http_status(500)
       expect(JSON.parse(response.body)['quiz_options']).to eq nil
     end
   end

--- a/test/controllers/api/v1/quiz/questions_controller_test.rb
+++ b/test/controllers/api/v1/quiz/questions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::Quiz::QuestionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## チケット
- [（バックエンド）クイズ問題と選択肢の表示](https://trello.com/c/uO5fPAIV)

# 実装内容
- クイズ問題、クイズの選択肢表示
- rspec実装（単体テスト、システムテスト）

## レスポンスJSON
- クイズ問題・選択肢
<img width="858" alt="スクリーンショット 2024-12-23 6 11 56" src="https://github.com/user-attachments/assets/bc088976-cb59-4092-a134-7dcf5cb45fef" />


- カテゴリーが選択されていない場合
<img width="807" alt="スクリーンショット 2024-12-23 6 12 24" src="https://github.com/user-attachments/assets/90f7c2f2-290f-445a-9cbf-5b76c4934549" />


## Rspec
```
UserCategory
  Soft Delete
    Soft deleted of UserCategory is nil
    Soft deleted of UserCategory is exist
    Soft deleted of UserCategory is restored

Categories
  Category list
    Display Success Category list
    Display Failure Category list

Quizzes
  Quiz Question and Options
    Display Success Quiz Question and Options
    Display Failure Quiz Question and Options

Sessions
  Login
    Login is successful if the user information is correct
    Login fails when user information is invalid
  Logout
    Success Logout
    Failed Logout (when already logged out)

Finished in 0.3046 seconds (files took 2.58 seconds to load)
11 examples, 0 failures
```


## 備考・注意点
- クイズ問題と選択肢は、カテゴリーが選択（=UserCategoryがDBに保存）されている状態で表示されます。